### PR TITLE
修复处理 reclass 分类时未正确处理空格的问题

### DIFF
--- a/ETagCN.pm
+++ b/ETagCN.pm
@@ -261,6 +261,7 @@ sub get_tags_from_EH ( $ua, $gID, $gToken, $jpntitle, $additionaltags, $db_path 
         $ehtitle = @$data[0]->{"title"};
     }
     my $ehcat = lc @$data[0]->{"category"};
+    $ehcat =~ s/\s+//g;
 
     push( @tags, "reclass:$ehcat" );
     if ($additionaltags) {


### PR DESCRIPTION


## 变更内容

修复 E-Hentai 分类标签在转换为 `reclass` 标签时未正确处理空格的问题。

## 背景

E-Hentai API 返回的分类可能包含空格，例如 `Artist CG`、`Image Set`。插件会将分类转换为 `reclass` 标签并用于 EhTagTranslation 汉化匹配，但词库中的对应 key 为 `artistcg`、`imageset`，不包含空格，导致分类无法正确翻译。
lanraragi截图：
<img width="176" height="43" alt="lanraragi截图" src="https://github.com/user-attachments/assets/81d48121-ba0f-45d5-8ab0-acc2873bc3ae" />
数据库截图：
<img width="199" height="134" alt="数据库截图" src="https://github.com/user-attachments/assets/d2a4c447-fa28-4219-b11a-193f6c61aefd" />
## 处理方式

在生成 `reclass` 标签前移除分类中的空格：

```perl
$ehcat =~ s/\s+//g;